### PR TITLE
feat: allow cancelling translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipynb-translator",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ipynb-translator",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ipynb-translator-multi-api",
   "displayName": "ipynb-translator (Multi-API)",
   "description": "Translate Jupyter Notebook Markdown cell using multiple LLM APIs (Zhipu, Aliyun, Volcano, Custom) and display the result below the original cell.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "local",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary
- allow cancelling single-cell translation progress notifications
- support cancelling in batch translations by aborting in-flight requests
- bump extension version to 0.2.2

## Testing
- `npm run compile`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm test` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68c13ab0f8e88325baa09e328d3ae868